### PR TITLE
Refactor Placement Validation

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -9,15 +9,13 @@ class Board
     @placement_validator = placement_validator
   end
 
-  def valid_coordinate?(coordinate)
-    @cells.include? coordinate
-  end
-
   def place(ship, coordinates)
-    cells_to_use = cells_from_coordinates(coordinates)
+    if valid_placement?(ship, coordinates)
+      cells_to_use = cells_from_coordinates(coordinates)
 
-    cells_to_use.each do |cell|
-      cell.place_ship(ship)
+      cells_to_use.each do |cell|
+        cell.place_ship(ship)
+      end
     end
   end
 
@@ -56,10 +54,25 @@ class Board
     render_string
   end
 
+  def coordinate_exists_on_board?(coordinate)
+    @cells.include? coordinate
+  end
+
   private
 
-  def render_row(rowchar, cells)
+  def valid_placement?(ship, coordinates)
+    board_problem = coordinates.any? do |coord|
+                      !coordinate_exists_on_board?(coord) || cell_occupied?(coord)
+                    end
 
+    coordinate_problem = !@placement_validator.validate(ship, coordinates)
+
+    !(board_problem || coordinate_problem)
+
+    # Another possible implementation below?
+    # return false if coordinates.any? { |coord| !coordinate_exists_on_board?(coord) || cell_occupied?(coord) }
+    # return false if !placement_validator.validate(ship, coordinates)
+    # true
   end
 
   def create_board

--- a/lib/placement_validator.rb
+++ b/lib/placement_validator.rb
@@ -6,7 +6,15 @@ class PlacementValidator
     # @board = Board.new
   end
 
-  def is_valid_length?(ship, coords)
+  def validate(ship, coordinates)
+    return false if !valid_coordinate_formats?(coordinates)
+    return false if !coordinates_match_ship_length?(ship, coordinates)
+    return false if !is_consecutive?(coordinates)
+    return false if is_diagonal?(coordinates)
+    true
+  end
+
+  def coordinates_match_ship_length?(ship, coords)
     ship.length == coords.count
   end
 
@@ -19,12 +27,11 @@ class PlacementValidator
       numbers << char[1].to_i
       letters << char[0].ord
     end
-    is_identical?(numbers)&&
-    is_identical?(letters)&&
-    valid_coordinate_lengths?(coord_chars)
+
+    is_identical?(numbers) && is_identical?(letters)
   end
 
-  def not_diagonal?(coords)
+  def is_diagonal?(coords)
     coord_chars = coords.map(&:chars)
     numbers = []
     letters = []
@@ -33,7 +40,8 @@ class PlacementValidator
       numbers << char[1].to_i
       letters << char[0].ord
     end
-    !(letters.uniq.count > 1 && numbers.uniq.count > 1 ) && valid_coordinate_lengths?(coord_chars)
+
+    letters.uniq.count > 1 && numbers.uniq.count > 1
   end
 
   def is_identical?(range)
@@ -43,18 +51,12 @@ class PlacementValidator
       is_range_consecutive?(range)
     end
   end
-  # Possibly?
+
   def is_range_consecutive?(range)
-    range.each_cons(2).all? {|a , b| b == a+1}
+    range.each_cons(2).all? { |a , b| b == a + 1 }
   end
 
-  def valid_placement?(ship, coords)
-
-  end
-
-  private
-
-  def valid_coordinate_lengths?(coordinates)
+  def valid_coordinate_formats?(coordinates)
     coordinates.all? { |coordinate| coordinate.length == 2 }
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -26,16 +26,16 @@ class BoardTest < Minitest::Test
     assert_equal 16, cells_hash.select { |k, v| v.is_a? Cell }.length
   end
 
-  def test_valid_coordinate_true
+  def test_coordinate_exists
     coordinate = "A1"
 
-    assert_equal true, @board.valid_coordinate?(coordinate)
+    assert_equal true, @board.coordinate_exists_on_board?(coordinate)
   end
 
-  def test_valid_coordinate_false
+  def test_coordinate_exists
     coordinate = "X9"
 
-    assert_equal false, @board.valid_coordinate?(coordinate)
+    assert_equal false, @board.coordinate_exists_on_board?(coordinate)
   end
 
   def test_place_ship

--- a/test/placement_validator_test.rb
+++ b/test/placement_validator_test.rb
@@ -19,20 +19,32 @@ class PlacementValidatorTest < MiniTest::Test
     assert_instance_of PlacementValidator, @validator
   end
 
-  def test_is_valid_length
-    assert_equal true, @validator.is_valid_length?(@submarine,["A1","A2"])
+  def test_validate
+    assert_equal false, @validator.validate(@cruiser, ["AA2", "A3"]) # Coordinate format
+    assert_equal false, @validator.validate(@submarine, ["A1", "A2", "A3"]) # Ship length =/= coordinate length
+    assert_equal false, @validator.validate(@cruiser, ["A1", "C1"]) # Not consecutive
+    assert_equal false, @validator.validate(@cruiser, ["A1", "A3", "A4"]) # Diagonal
+    assert_equal true, @validator.validate(@cruiser, ["A3", "B3", "C3"]) # All good
   end
 
-  def test_is_NOT_valid_length
-    assert_equal false, @validator.is_valid_length?(@submarine,["A1","A2","A3"])
+  def test_coordinates_match_ship_length
+    assert_equal true, @validator.coordinates_match_ship_length?(@submarine, ["A1", "A2"])
+  end
+
+  def test_rejects_coordinates_not_matching_ship_length
+    assert_equal false, @validator.coordinates_match_ship_length?(@submarine, ["A1", "A2", "A3"])
+  end
+
+  def test_rejects_weird_coordinates
+    assert_equal false, @validator.valid_coordinate_formats?(["AA2", "A3"])
   end
 
   def test_is_consecutive
     assert_equal true, @validator.is_consecutive?(["A1", "A2", "A3"])
     assert_equal true, @validator.is_consecutive?(["A1", "A2"])
     assert_equal true, @validator.is_consecutive?(["B1", "C1", "D1"])
-    assert_equal true, @validator.is_consecutive?(["B1", "B2","B3"])
-    assert_equal true, @validator.is_consecutive?(["D2", "D3","D4"])
+    assert_equal true, @validator.is_consecutive?(["B1", "B2", "B3"])
+    assert_equal true, @validator.is_consecutive?(["D2", "D3", "D4"])
   end
 
   def test_is_not_consecutive
@@ -40,20 +52,17 @@ class PlacementValidatorTest < MiniTest::Test
     assert_equal false, @validator.is_consecutive?(["A1", "A1", "A4"])
     assert_equal false, @validator.is_consecutive?(["A1", "C1"])
     assert_equal false, @validator.is_consecutive?(["A3", "A2", "A1"])
-    assert_equal false, @validator.is_consecutive?(["AA1", "A3", "A44"])
   end
 
-  def test_it_is_not_diagonal #which is good
-    assert_equal true, @validator.not_diagonal?(["A1", "A3", "A4"])
-    assert_equal true, @validator.not_diagonal?(["A1", "C1"])
-    assert_equal true, @validator.not_diagonal?(["A3", "A2", "A1"])
-    assert_equal true, @validator.not_diagonal?(["A1", "A3", "A4"])
+  def test_it_is_diagonal
+    assert_equal true, @validator.is_diagonal?(["A1", "B2", "C3"])
+    assert_equal true, @validator.is_diagonal?(["B2", "C3", "D4"])
+    assert_equal true, @validator.is_diagonal?(["C2", "D3"])
   end
 
-  def test_it_is_not_not_diagonal #which is bad
-    assert_equal false, @validator.not_diagonal?(["A1", "B2", "C3"])
-    assert_equal false, @validator.not_diagonal?(["B2", "C3", "D4"])
-    assert_equal false, @validator.not_diagonal?(["C2", "D3"])
-    assert_equal false, @validator.not_diagonal?(["C2C", "DD3"])
+  def test_it_is_not_diagonal
+    assert_equal false, @validator.is_diagonal?(["A1", "A3", "A4"])
+    assert_equal false, @validator.is_diagonal?(["A1", "C1"])
+    assert_equal false, @validator.is_diagonal?(["A3", "A2", "A1"])
   end
 end


### PR DESCRIPTION
## Added / Modified
- Refactor while hooking up placement validation to `Board#place`
- Had to merge main into branch b/c I was behind the last edits @b-enji-cmd made
  - Board & PlacementValidator tests run fine

## Next Steps
- I identified a bug in the placement validation code which lets coordinates like `["A1", "A1", "A1"]` pass as valid.  I will address this in a new branch.